### PR TITLE
travis-ci: adding cache for directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_cache:
 cache:
   - directories:
     - $HOME/Library/Caches/Homebrew
-    - /usr/local/Homebrew/Library/Taps/*/*
 
 before_install:
   - brew tap includeos/includeos

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 os: osx
+osx_image: xcode10.2
+
 language: bash
 
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@ language: bash
 git:
   depth: false
 
+before_cache:
+  - brew cleanup
+
+cache:
+  - directories:
+    - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew/Library/Taps/*/*
+
 before_install:
   - brew tap includeos/includeos
 
@@ -26,7 +34,7 @@ script:
     then
       echo "Hello World -  Success! :)"
     else
-      echo "Failed to reach Success :("
+      echo "Failed :("
     fi
 
 after_script:


### PR DESCRIPTION
Added cache as follows:

```
before_cache:
  - brew cleanup

cache:
  - directories:
    - $HOME/Library/Caches/Homebrew
    - /usr/local/Homebrew/Library/Taps/*/*
```

Caching the above directories, to keep a cache of the homebrew pacakge installations as well as the pinned taps.

As tested, it has speed up the job by 4 minutes ( _note that caching of data after changes are detected in the build, takes a few minutes as well_ ).

Maybe this can be further optimized to only cache exactly the packages we need.

**Reviews Requested from:**
@MagnusS 
@mnordsletten 