### PR TITLE
travis: fixed fail job if check unsuccessful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,15 @@ before_script:
 script:
   - conan install hello_world -pr clang-6.0-macos-x86_64
   - source activate.sh
-  - cmake hello_world
+  - cmake -DFOR_PRODUCTION=OFF hello_world
   - cmake --build .
-  - gtimeout 7 boot hello > hello_log.txt || true
+  - gtimeout 10 boot hello 2>&1 | tee hello.log  || true
   - |
-    if grep -F "Running [ Hello world - OS included ]" hello_log.txt
+    if grep -F "Running [ Hello world - OS included ]" hello.log
     then
       echo "Hello World -  Success! :)"
     else
-      echo "Failed :("
+      exit 1
     fi
 
 after_script:


### PR DESCRIPTION
The pipeline is green, even when the condition is `false`.
Now it will exit with 1 when the condition is `false`.
Other minor changes:
- turned production off `cmake -DFOR_PRODUCTION=OFF hello_world`
- increased timeout `gtimeout 10`
- changed name of log file: `hello_log-txt` to `hello.log`
- returns standard out and standard error to console and to file. `boot hello 2>&1 | tee hello.log`